### PR TITLE
Extract ViewPumpContextWrapper from the library

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,18 +130,26 @@ Kotlin:
 ```kotlin
 class BaseActivity : AppCompatActivity() {
     private val delegateHolder = PhilologyAppCompatDelegateHolder()
-    override fun getDelegate() = delegateHolder.getDelegate(super.getDelegate())
+    override fun getDelegate() = delegateHolder.getDelegate(super.getDelegate()) {
+        ViewPumpContextWrapper.wrap(Philology.wrap(it))
+    }
 }
 ```
 
 Java:
 ```java
 public class BaseActivity extends AppCompatActivity {
-    private PhilologyAppCompatDelegateHolder delegateHolder = new PhilologyAppCompatDelegateHolder();
+    private final PhilologyAppCompatDelegateHolder delegateHolder = new PhilologyAppCompatDelegateHolder();
+
     @NonNull
     @Override
     public AppCompatDelegate getDelegate() {
-        return delegateHolder.getDelegate(super.getDelegate());
+        return delegateHolder.getDelegate(super.getDelegate(), new Function1<Context, Context>() {
+                    @Override
+                    public Context invoke(Context context) {
+                        return ViewPumpContextWrapper.wrap(Philology.INSTANCE.wrap(context));
+                    }
+                });
     }
 }
 ```

--- a/philology/src/main/java/com/jcminarro/philology/PhilologyAppCompatDelegateHolder.kt
+++ b/philology/src/main/java/com/jcminarro/philology/PhilologyAppCompatDelegateHolder.kt
@@ -1,15 +1,17 @@
 package com.jcminarro.philology
 
+import android.content.Context
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.appcompat.app.BaseContextWrappingDelegate
-import io.github.inflationx.viewpump.ViewPumpContextWrapper
 
 class PhilologyAppCompatDelegateHolder {
 
     private var baseContextWrappingDelegate: AppCompatDelegate? = null
 
-    fun getDelegate(superDelegate: AppCompatDelegate) = baseContextWrappingDelegate
-        ?: BaseContextWrappingDelegate(superDelegate) { context ->
-            ViewPumpContextWrapper.wrap(Philology.wrap(context))
-        }.apply { baseContextWrappingDelegate = this }
+    fun getDelegate(
+        superDelegate: AppCompatDelegate,
+        onAttachBaseContext: (Context) -> Context
+    ) = baseContextWrappingDelegate ?: BaseContextWrappingDelegate(
+        superDelegate, onAttachBaseContext
+    ).apply { baseContextWrappingDelegate = this }
 }

--- a/sample/src/main/java/com/jcminarro/philology/sample/MainActivity.kt
+++ b/sample/src/main/java/com/jcminarro/philology/sample/MainActivity.kt
@@ -6,13 +6,17 @@ import android.text.TextWatcher
 import android.widget.EditText
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
+import com.jcminarro.philology.Philology
 import com.jcminarro.philology.PhilologyAppCompatDelegateHolder
 import com.jcminarro.sample.R
+import io.github.inflationx.viewpump.ViewPumpContextWrapper
 
 class MainActivity : AppCompatActivity() {
 
     private val delegateHolder = PhilologyAppCompatDelegateHolder()
-    override fun getDelegate() = delegateHolder.getDelegate(super.getDelegate())
+    override fun getDelegate() = delegateHolder.getDelegate(super.getDelegate()) {
+        ViewPumpContextWrapper.wrap(Philology.wrap(it))
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)


### PR DESCRIPTION
Leave `ViewPumpContextWrapper` to be used by the client